### PR TITLE
VsButton fix “TypeError: Cannot read property ‘clientWidth’ of undefine”

### DIFF
--- a/src/components/vsButton/vsButton.vue
+++ b/src/components/vsButton/vsButton.vue
@@ -238,6 +238,10 @@ export default {
     blurButton(event){
       this.$emit('blur',event)
       this.$nextTick(() => {
+        if (this._isBeingDestroyed || this._isDestroyed ) {
+          return
+        }
+
         if(this.type == 'border' || this.type == 'flat'){
           this.opacity = 0
           setTimeout( () => {
@@ -246,11 +250,14 @@ export default {
           this.isActive = false
         }
       });
-      
+
     },
     clickButton(event){
       this.$emit('click', event)
       this.$nextTick(() => {
+        if (this._isBeingDestroyed || this._isDestroyed ) {
+          return
+        }
         if(this.isActive){
           return
         }
@@ -301,7 +308,7 @@ export default {
           }, this.time * 1100)
         }
       });
-      
+
 
     },
     isColor(){


### PR DESCRIPTION
**Bug**: Sometimes when we click a VsButton it throws an error `Console error: Error in nextTick: “TypeError: Cannot read property ‘clientWidth’ of undefine”`. That is caused because click functions executes an `this.$nextTick()` and button may not exist in next tick (eg: on transitions between pages or ir VsDialogs).

It is reproducible in Vuesax documentation: https://lusaxweb.github.io/vuesax/components/dialog.html. Open and then close any alert and you should see and error on the console.