### PR TITLE
Fix buttom with no type="button" in VsUpload, triggering submit if inside a form

### DIFF
--- a/src/components/vsUpload/vsUpload.vue
+++ b/src/components/vsUpload/vsUpload.vue
@@ -35,6 +35,7 @@
             height: `${img.percent}%`
           }"
           class="btn-upload-file"
+          type="button"
           @click="upload(index)">
           <i
             translate="no"


### PR DESCRIPTION
Upload file button in **VsUpload** component has no `type="button"` property, so when clicked if **VsUpload** is inside a form it will trigger its submit event.